### PR TITLE
Debug attribute is no longer supported.

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context path="" debug="100" privileged="true" reloadable="true" crossContext="true">
+<Context path="" privileged="true" reloadable="true" crossContext="true">
 </Context>


### PR DESCRIPTION
Hi.

I fix the `context.xml` file.
After reviewing the official documentation, we found that the debug attribute was not in the list.

To modify the source code, I refer to the following document:

- [Common Attributes - Apache Tomcat 8 Configuration Reference](https://tomcat.apache.org/tomcat-8.5-doc/config/context.html#Attributes)

How about this?